### PR TITLE
Use generateBundle to address warnings with rollup v1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default (options = {}) => {
 
       return ''
     },
-    ongenerate: (opts, rendered) => {
+    generateBundle: (opts, rendered) => {
       // No stylesheet needed
       if (!changes || options.output === false) {
         return


### PR DESCRIPTION
As of `rollup@1.0.0` the following warning is shown on build:

```cmd
The ongenerate hook used by plugin css is deprecated. The generateBundle hook should be used instead.
```

This replaces the `ongenerate` hook with the new `generateBundle` method as suggested